### PR TITLE
Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rust:
 script:
   - cargo build
   - cargo build --release
+  - cargo build --no-default-features
+  - cargo build --release --no-default-features
   - cargo test
   - cargo test --release
   - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["scoped", "thread", "atomic", "cache"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
 [features]
+default = ["use_std"]
+use_std = []
 nightly = []
 
 [dependencies]

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -1,7 +1,7 @@
-use std::fmt;
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::ptr;
+use core::fmt;
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
 
 cfg_if! {
     if #[cfg(feature = "nightly")] {
@@ -25,7 +25,7 @@ cfg_if! {
             }
         }
     } else {
-        use std::marker::PhantomData;
+        use core::marker::PhantomData;
 
         #[derive(Clone)]
         struct Inner<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 #![cfg_attr(feature = "nightly", feature(attr_literals, repr_align))]
+#![cfg_attr(not(feature = "use_std"), no_std)]
+
+#[cfg(feature = "use_std")]
+extern crate core;
 
 #[macro_use]
 extern crate cfg_if;
 
-pub mod atomic_option;
 pub mod cache_padded;
+#[cfg(feature = "use_std")]
+pub mod atomic_option;
+#[cfg(feature = "use_std")]
 pub mod scoped;


### PR DESCRIPTION
This is a first step for supporting `no_std` in crossbeam-epoch.

It basically disables `AtomicOption` and scoped threads if the "std" feature isn't enabled (it is enabled by default).