### PR TITLE
Add support for Rust 1.12 and fix bug in CachePadded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.12.1
 
 script:
   - cargo build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Rust 1.12.1.
+
+### Fixed
+- Call `T::clone` when cloning a `CachePadded<T>`.
 
 ## [0.2.1] - 2017-11-26
 

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -3,12 +3,31 @@ use core::mem;
 use core::ops::{Deref, DerefMut};
 use core::ptr;
 
+
 cfg_if! {
     if #[cfg(feature = "nightly")] {
-        #[derive(Clone)]
-        #[repr(align(64))]
-        struct Inner<T> {
-            value: T,
+        // This trick allows use to support rustc 1.12.1, which does not support the
+        // #[repr(align(n))] syntax. Using the attribute makes the parses fail over.
+        // It is, however, okay to use it within a macro, since it would be parsed
+        // in a later stage, but that never occurs due to the cfg_if.
+        // TODO(Vtec234): remove this crap when we drop support for 1.12.
+        macro_rules! nightly_inner {
+            () => (
+                #[derive(Clone)]
+                #[repr(align(64))]
+                pub(crate) struct Inner<T> {
+                    value: T,
+                }
+            )
+        }
+        nightly_inner!();
+
+        impl<T> Inner<T> {
+            pub(crate) fn new(t: T) -> Inner<T> {
+                Self {
+                    value: t
+                }
+            }
         }
 
         impl<T> Deref for Inner<T> {
@@ -27,13 +46,26 @@ cfg_if! {
     } else {
         use core::marker::PhantomData;
 
-        #[derive(Clone)]
         struct Inner<T> {
-            bytes: [u8; 64],
+            bytes: [u64; 8],
 
-            /// `[T; 0]` ensures correct alignment.
+            /// `[T; 0]` ensures alignment is at least that of `T`.
             /// `PhantomData<T>` signals that `CachePadded<T>` contains a `T`.
             _marker: ([T; 0], PhantomData<T>),
+        }
+
+        impl<T> Inner<T> {
+            fn new(t: T) -> Inner<T> {
+                assert!(mem::size_of::<T>() <= mem::size_of::<Self>());
+                assert!(mem::align_of::<T>() <= mem::align_of::<Self>());
+
+                unsafe {
+                    let mut inner: Self = mem::uninitialized();
+                    let p: *mut T = &mut *inner;
+                    ptr::write(p, t);
+                    inner
+                }
+            }
         }
 
         impl<T> Deref for Inner<T> {
@@ -56,6 +88,13 @@ cfg_if! {
                 unsafe {
                     ptr::drop_in_place(p);
                 }
+            }
+        }
+
+        impl<T: Clone> Clone for Inner<T> {
+            fn clone(&self) -> Inner<T> {
+                let val = self.deref().clone();
+                Self::new(val)
             }
         }
     }
@@ -91,16 +130,8 @@ impl<T> CachePadded<T> {
     ///
     /// If `nightly` is not enabled and `T` is larger than 64 bytes, this function will panic.
     pub fn new(t: T) -> CachePadded<T> {
-        assert!(mem::size_of::<T>() <= mem::size_of::<CachePadded<T>>());
-        assert!(mem::align_of::<T>() <= mem::align_of::<CachePadded<T>>());
-
-        unsafe {
-            let mut padded = CachePadded {
-                inner: mem::uninitialized(),
-            };
-            let p: *mut T = &mut *padded;
-            ptr::write(p, t);
-            padded
+        CachePadded::<T> {
+            inner: Inner::new(t)
         }
     }
 }
@@ -164,6 +195,8 @@ mod test {
         assert_eq!(x.1, 37);
     }
 
+    // An alignment of 64 is only guaranteed on nightly.
+    #[cfg(feature = "nightly")]
     #[test]
     fn distance() {
         let arr = [CachePadded::new(17u8), CachePadded::new(37u8)];
@@ -237,5 +270,24 @@ mod test {
         let a = CachePadded::new(17);
         let b = a.clone();
         assert_eq!(*a, *b);
+    }
+
+    #[test]
+    fn runs_custom_clone() {
+        let count = Cell::new(0);
+
+        struct Foo<'a>(&'a Cell<usize>);
+
+        impl<'a> Clone for Foo<'a> {
+            fn clone(&self) -> Foo<'a> {
+                self.0.set(self.0.get() + 1);
+                Foo::<'a>(self.0)
+            }
+        }
+
+        let a = CachePadded::new(Foo(&count));
+        a.clone();
+
+        assert_eq!(count.get(), 1);
     }
 }

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -7,7 +7,7 @@ use core::ptr;
 cfg_if! {
     if #[cfg(feature = "nightly")] {
         // This trick allows use to support rustc 1.12.1, which does not support the
-        // #[repr(align(n))] syntax. Using the attribute makes the parses fail over.
+        // #[repr(align(n))] syntax. Using the attribute makes the parser fail over.
         // It is, however, okay to use it within a macro, since it would be parsed
         // in a later stage, but that never occurs due to the cfg_if.
         // TODO(Vtec234): remove this crap when we drop support for 1.12.
@@ -191,14 +191,12 @@ mod test {
         assert_eq!(x.1, 37);
     }
 
-    // An alignment of 64 is only guaranteed on nightly.
-    #[cfg(feature = "nightly")]
     #[test]
     fn distance() {
         let arr = [CachePadded::new(17u8), CachePadded::new(37u8)];
         let a = &*arr[0] as *const u8;
         let b = &*arr[1] as *const u8;
-        assert_eq!(a.wrapping_offset(64), b);
+        assert!(unsafe { a.offset(64) } <= b);
     }
 
     #[test]

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -47,7 +47,7 @@ cfg_if! {
         use core::marker::PhantomData;
 
         struct Inner<T> {
-            bytes: [u64; 8],
+            bytes: [u8; 64],
 
             /// `[T; 0]` ensures alignment is at least that of `T`.
             /// `PhantomData<T>` signals that `CachePadded<T>` contains a `T`.
@@ -130,9 +130,7 @@ impl<T> CachePadded<T> {
     ///
     /// If `nightly` is not enabled and `T` is larger than 64 bytes, this function will panic.
     pub fn new(t: T) -> CachePadded<T> {
-        CachePadded::<T> {
-            inner: Inner::new(t)
-        }
+        CachePadded::<T> { inner: Inner::new(t) }
     }
 }
 
@@ -158,9 +156,7 @@ impl<T: Default> Default for CachePadded<T> {
 
 impl<T: Clone> Clone for CachePadded<T> {
     fn clone(&self) -> Self {
-        CachePadded {
-            inner: self.inner.clone(),
-        }
+        CachePadded { inner: self.inner.clone() }
     }
 }
 
@@ -240,7 +236,10 @@ mod test {
 
     #[test]
     fn debug() {
-        assert_eq!(format!("{:?}", CachePadded::new(17u64)), "CachePadded { 17 }");
+        assert_eq!(
+            format!("{:?}", CachePadded::new(17u64)),
+            "CachePadded { 17 }"
+        );
     }
 
     #[test]


### PR DESCRIPTION
As title says. This is for rayon-core, which still uses 1.12. The CachePadded bug was that it didn't run custom `Clone`.