### PR TITLE
chore: add feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic, integer_atomics))]
+#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic, integer_atomics, repr_align, attr_literals))]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
 #[cfg(feature = "use_std")]


### PR DESCRIPTION
When I build the utils with `1.28.0-nightly (f352115d5 2018-05-15)`, it could not compile `crossbeam-utils`.

```
error: the struct `#[repr(align(u16))]` attribute is experimental (see issue #33626)
  --> /Users/loveknut/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.4.0/src/cache_padded.rs:19:1
   |
19 | #[repr(align(64))]
   | ^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(repr_align)] to the crate attributes to enable

error: non-string literals in attributes, or string literals in top-level positions, are experimental (see issue #34981)
  --> /Users/loveknut/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-utils-0.4.0/src/cache_padded.rs:19:1
   |
19 | #[repr(align(64))]
   | ^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(attr_literals)] to the crate attributes to enable

error: aborting due to 2 previous errors

error: Could not compile `crossbeam-utils`.
```

so I add this two feature.