### PR TITLE
Fix `cargo doc` in nightly

### DIFF
--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -62,6 +62,7 @@
 /// `'static` lifetime. One way of giving it a proper lifetime is to use an [`Arc`][arc]:
 ///
 /// [arc]: http://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+/// [spawn]: https://doc.rust-lang.org/stable/std/thread/fn.spawn.html
 ///
 /// ```
 /// use std::sync::Arc;


### PR DESCRIPTION
```
warning: `[spawn]` cannot be resolved, ignoring it...
  --> src/scoped.rs:16:28
   |
16 | /// [`std::thread::spawn`][spawn]:
   |                            ^^^^^ cannot be resolved, ignoring
   |
   = note: #[warn(intra_doc_link_resolution_failure)] on by default
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[spawn]` cannot be resolved, ignoring it...
  --> src/scoped.rs:16:28
   |
16 | /// [`std::thread::spawn`][spawn]:
   |                            ^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[spawn]` cannot be resolved, ignoring it...
  --> src/scoped.rs:61:36
   |
61 | /// Because [`std::thread::spawn`][spawn] doesn't know about this scope, it requires a
   |                                    ^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

```

$ rustc --version
rustc 1.28.0-nightly (01cc982e9 2018-06-24)