### PR TITLE
Bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-07-22
+### Changed
+- Reorganize sub-modules and rename functions.
+
 ## [0.4.1] - 2018-06-28
 ### Fixed
 - Fix a documentation link.
@@ -66,7 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Old implementation of `CachePadded` from `crossbeam` version 0.3.0
 
-[Unreleased]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/crossbeam-rs/crossbeam-utils/compare/v0.3.1...v0.3.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbeam-utils"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
It's a pre-requisite for Crossbeam 0.4.0 release.