### PR TITLE
Use vector for dtors in thread and remove defer()

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -152,9 +152,7 @@ where
 {
     let closure: Box<FnBox<T> + 'a> = Box::new(f);
     let closure: Box<FnBox<T> + Send> = mem::transmute(closure);
-    builder.spawn(move || {
-        closure.call_box()
-    })
+    builder.spawn(move || closure.call_box())
 }
 
 pub struct Scope<'env> {
@@ -170,22 +168,22 @@ pub struct Scope<'env> {
 
 struct JoinState<T> {
     join_handle: thread::JoinHandle<()>,
-    result: ScopedThreadResult<T>
+    result: ScopedThreadResult<T>,
 }
 
 impl<T> JoinState<T> {
     fn new(join_handle: thread::JoinHandle<()>, result: ScopedThreadResult<T>) -> JoinState<T> {
         JoinState {
             join_handle,
-            result
+            result,
         }
     }
 
     fn join(self) -> thread::Result<T> {
         let result = self.result;
-        self.join_handle.join().map(|_| {
-            result.lock().unwrap().take().unwrap()
-        })
+        self.join_handle
+            .join()
+            .map(|_| result.lock().unwrap().take().unwrap())
     }
 }
 


### PR DESCRIPTION
I replaced a custom list with `Vec` and corrected comments.

Fixes the point 1 of #29 
Fixes the point 3 of #29 
Closes #33 (actually using vector for dtors was intertwined with removing defer(); sorry for making a duplicated PR.)

cc @oliver-giersch @stjepang 