### PR TITLE
Rename lifetimes for clarity

### DIFF
--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -165,7 +165,7 @@ mod test {
         }
 
         let a = CachePadded::new(Foo(&count));
-        a.clone();
+        let _ = a.clone();
 
         assert_eq!(count.get(), 1);
     }


### PR DESCRIPTION
Hopefully this makes it clearer what borrows what.

* `'env` refers to the environment outside the scope (that's the stuff scoped threads can borrow).
* `'scope` refers to the `Scope` inside the scope.

For example, in `spawn`:

```rust
pub fn spawn<'scope, F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
where
    F: FnOnce() -> T,
    F: Send + 'env,
    T: Send + 'env,
{
    // ...
}
```

Now it's easy to see that `ScopedJoinHandle` borrows the `Scope`, while `F` and `T` borrow only the environment outside the scope.