### PR TITLE
code simplification of thread joining + code rearrangements

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -120,10 +120,10 @@ use std::thread;
 ///
 /// [`std::thread::spawn`]: https://doc.rust-lang.org/stable/std/thread/fn.spawn.html
 pub unsafe fn spawn_unchecked<'a, F, T>(f: F) -> thread::JoinHandle<T>
-    where
-        F: FnOnce() -> T,
-        F: Send + 'a,
-        T: Send + 'static,
+where
+    F: FnOnce() -> T,
+    F: Send + 'a,
+    T: Send + 'static,
 {
     let builder = thread::Builder::new();
     builder_spawn_unchecked(builder, f).unwrap()
@@ -137,10 +137,10 @@ pub unsafe fn builder_spawn_unchecked<'a, F, T>(
     builder: thread::Builder,
     f: F,
 ) -> io::Result<thread::JoinHandle<T>>
-    where
-        F: FnOnce() -> T,
-        F: Send + 'a,
-        T: Send + 'static,
+where
+    F: FnOnce() -> T,
+    F: Send + 'a,
+    T: Send + 'static,
 {
     let closure: Box<FnBox<T> + 'a> = Box::new(f);
     let closure: Box<FnBox<T> + Send> = mem::transmute(closure);
@@ -167,8 +167,8 @@ pub unsafe fn builder_spawn_unchecked<'a, F, T>(
 /// }).unwrap();
 /// ```
 pub fn scope<'env, F, R>(f: F) -> thread::Result<R>
-    where
-        F: FnOnce(&Scope<'env>) -> R,
+where
+    F: FnOnce(&Scope<'env>) -> R,
 {
     let scope = Default::default();
 
@@ -199,10 +199,10 @@ impl<'env> Scope<'env> {
     ///
     /// [`spawn`]: https://doc.rust-lang.org/std/thread/fn.spawn.html
     pub fn spawn<'scope, F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
-        where
-            F: FnOnce() -> T,
-            F: Send + 'env,
-            T: Send + 'env,
+    where
+        F: FnOnce() -> T,
+        F: Send + 'env,
+        T: Send + 'env,
     {
         self.builder().spawn(f).unwrap()
     }
@@ -260,10 +260,10 @@ impl<'scope, 'env: 'scope> ScopedThreadBuilder<'scope, 'env> {
 
     /// Spawns a new thread, and returns a join handle for it.
     pub fn spawn<F, T>(self, f: F) -> io::Result<ScopedJoinHandle<'scope, T>>
-        where
-            F: FnOnce() -> T,
-            F: Send + 'env,
-            T: Send + 'env,
+    where
+        F: FnOnce() -> T,
+        F: Send + 'env,
+        T: Send + 'env,
     {
         let result = Arc::new(Mutex::new(None));
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -182,10 +182,7 @@ where
     let mut panics = scope.join_all();
 
     if panics.is_empty() {
-        match result {
-            Ok(res) => Ok(res),
-            Err(err) => Err(Box::new(vec![err])),
-        }
+        result.map_err(|res| Box::new(vec![res]) as _)
     } else {
         if let Err(err) = result {
             panics.reserve(1);


### PR DESCRIPTION
First of I apologize for not separating concerns properly with this PR, in hindsight I should have probably split the rearrangement and the simplification into two parts.

I found the arrangement of the code quite frustrating and not well ordered, so I went ahead and rearranged it in (hopefully) a logical and consistent way:

1. Public/More important components are now at the top of the file (the `scope` function, `Scope` struct, etc).
2. Private/Less important components are now at the bottom of the file (`FnBox` trait for instance).
3. Structs and impls are now right behind each other.
4. Trait impls are arranged around the definition/implementation of a struct (`Drop`, `Debug` after the impl, Send + Sync before the struct, etc.)
5. `ScopedThreadBuilder` and `ScopedJoinHandle` are now arranged in that order.

The other thing I did was simplify the `scope` function.
The `panics` vector wasn't really necessary, since only the last panic was returned anyway (the vector was just popped once). So I removed it and simply made the `join_all` function return the last panic.

Since the `scope` function uses a `catch_unwind` call I figured it should now be exception-safe and removed the `Drop` impl, which allowed me to simplify the `join_all` function in the first place.