### PR TITLE
make the the threads.rs doc comment a module level comment

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,111 +1,112 @@
-/// Scoped thread.
-///
-/// # Examples
-///
-/// A basic scoped thread:
-///
-/// ```
-/// crossbeam_utils::thread::scope(|scope| {
-///     scope.spawn(|| {
-///         println!("Hello from a scoped thread!");
-///     });
-/// }).unwrap();
-/// ```
-///
-/// When writing concurrent Rust programs, you'll sometimes see a pattern like this, using
-/// [`std::thread::spawn`]:
-///
-/// ```ignore
-/// let array = [1, 2, 3];
-/// let mut guards = vec![];
-///
-/// for i in &array {
-///     let guard = std::thread::spawn(move || {
-///         println!("element: {}", i);
-///     });
-///
-///     guards.push(guard);
-/// }
-///
-/// for guard in guards {
-///     guard.join().unwrap();
-/// }
-/// ```
-///
-/// The basic pattern is:
-///
-/// 1. Iterate over some collection.
-/// 2. Spin up a thread to operate on each part of the collection.
-/// 3. Join all the threads.
-///
-/// However, this code actually gives an error:
-///
-/// ```text
-/// error: `array` does not live long enough
-/// for i in &array {
-///           ^~~~~
-/// in expansion of for loop expansion
-/// note: expansion site
-/// note: reference must be valid for the static lifetime...
-/// note: ...but borrowed value is only valid for the block suffix following statement 0 at ...
-///     let array = [1, 2, 3];
-///     let mut guards = vec![];
-///
-///     for i in &array {
-///         let guard = std::thread::spawn(move || {
-///             println!("element: {}", i);
-/// ...
-/// error: aborting due to previous error
-/// ```
-///
-/// Because [`std::thread::spawn`] doesn't know about this scope, it requires a `'static` lifetime.
-/// One way of giving it a proper lifetime is to use an [`Arc`]:
-///
-/// [`Arc`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
-/// [`std::thread::spawn`]: https://doc.rust-lang.org/stable/std/thread/fn.spawn.html
-///
-/// ```
-/// use std::sync::Arc;
-///
-/// let array = Arc::new([1, 2, 3]);
-/// let mut guards = vec![];
-///
-/// for i in 0..array.len() {
-///     let a = array.clone();
-///
-///     let guard = std::thread::spawn(move || {
-///         println!("element: {}", a[i]);
-///     });
-///
-///     guards.push(guard);
-/// }
-///
-/// for guard in guards {
-///     guard.join().unwrap();
-/// }
-/// ```
-///
-/// But this introduces unnecessary allocation, as `Arc<T>` puts its data on the heap, and we
-/// also end up dealing with reference counts. We know that we're joining the threads before
-/// our function returns, so just taking a reference _should_ be safe. Rust can't know that,
-/// though.
-///
-/// Enter scoped threads. Here's our original example, using `spawn` from crossbeam rather
-/// than from `std::thread`:
-///
-/// ```
-/// let array = [1, 2, 3];
-///
-/// crossbeam_utils::thread::scope(|scope| {
-///     for i in &array {
-///         scope.spawn(move || {
-///             println!("element: {}", i);
-///         });
-///     }
-/// }).unwrap();
-/// ```
-///
-/// Much more straightforward.
+//! Scoped thread.
+//!
+//! # Examples
+//!
+//! A basic scoped thread:
+//!
+//! ```
+//! crossbeam_utils::thread::scope(|scope| {
+//!     scope.spawn(|| {
+//!         println!("Hello from a scoped thread!");
+//!     });
+//! }).unwrap();
+//! ```
+//!
+//! When writing concurrent Rust programs, you'll sometimes see a pattern like this, using
+//! [`std::thread::spawn`]:
+//!
+//! ```ignore
+//! let array = [1, 2, 3];
+//! let mut guards = vec![];
+//!
+//! for i in &array {
+//!     let guard = std::thread::spawn(move || {
+//!         println!("element: {}", i);
+//!     });
+//!
+//!     guards.push(guard);
+//! }
+//!
+//! for guard in guards {
+//!     guard.join().unwrap();
+//! }
+//! ```
+//!
+//! The basic pattern is:
+//!
+//! 1. Iterate over some collection.
+//! 2. Spin up a thread to operate on each part of the collection.
+//! 3. Join all the threads.
+//!
+//! However, this code actually gives an error:
+//!
+//! ```text
+//! error: `array` does not live long enough
+//! for i in &array {
+//!           ^~~~~
+//! in expansion of for loop expansion
+//! note: expansion site
+//! note: reference must be valid for the static lifetime...
+//! note: ...but borrowed value is only valid for the block suffix following statement 0 at ...
+//!     let array = [1, 2, 3];
+//!     let mut guards = vec![];
+//!
+//!     for i in &array {
+//!         let guard = std::thread::spawn(move || {
+//!             println!("element: {}", i);
+//! ...
+//! error: aborting due to previous error
+//! ```
+//!
+//! Because [`std::thread::spawn`] doesn't know about this scope, it requires a `'static` lifetime.
+//! One way of giving it a proper lifetime is to use an [`Arc`]:
+//!
+//! [`Arc`]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html
+//! [`std::thread::spawn`]: https://doc.rust-lang.org/stable/std/thread/fn.spawn.html
+//!
+//! ```
+//! use std::sync::Arc;
+//!
+//! let array = Arc::new([1, 2, 3]);
+//! let mut guards = vec![];
+//!
+//! for i in 0..array.len() {
+//!     let a = array.clone();
+//!
+//!     let guard = std::thread::spawn(move || {
+//!         println!("element: {}", a[i]);
+//!     });
+//!
+//!     guards.push(guard);
+//! }
+//!
+//! for guard in guards {
+//!     guard.join().unwrap();
+//! }
+//! ```
+//!
+//! But this introduces unnecessary allocation, as `Arc<T>` puts its data on the heap, and we
+//! also end up dealing with reference counts. We know that we're joining the threads before
+//! our function returns, so just taking a reference _should_ be safe. Rust can't know that,
+//! though.
+//!
+//! Enter scoped threads. Here's our original example, using `spawn` from crossbeam rather
+//! than from `std::thread`:
+//!
+//! ```
+//! let array = [1, 2, 3];
+//!
+//! crossbeam_utils::thread::scope(|scope| {
+//!     for i in &array {
+//!         scope.spawn(move || {
+//!             println!("element: {}", i);
+//!         });
+//!     }
+//! }).unwrap();
+//! ```
+//!
+//! Much more straightforward.
+
 use std::any::Any;
 use std::cell::RefCell;
 use std::fmt;


### PR DESCRIPTION
It looks like this long comment was intended to be visible in the docs. I could be wrong though!